### PR TITLE
feat: use RunnerDBMigration helper instead of static helper

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.ProjectionHandling.LastChangedList/LastChangedListMigrationsHelper.cs
+++ b/src/Be.Vlaanderen.Basisregisters.ProjectionHandling.LastChangedList/LastChangedListMigrationsHelper.cs
@@ -1,59 +1,25 @@
 namespace Be.Vlaanderen.Basisregisters.ProjectionHandling.LastChangedList
 {
-    using System;
-    using System.Data.SqlClient;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
-    using Polly;
+    using Runner;
 
-    public class MigrationsLogger { }
-
-    public static class LastChangedListMigrationsHelper
+    public class LastChangedListMigrationsHelper : RunnerDbContextMigrationHelper<LastChangedListContext>
     {
-        public static async Task RunAsync(
-            string connectionString,
-            ILoggerFactory loggerFactory = null,
-            CancellationToken cancellationToken = default)
+        public LastChangedListMigrationsHelper(string connectionString, ILoggerFactory loggerFactory)
+            : base(
+                connectionString,
+                new HistoryConfiguration
+                {
+                    Schema = LastChangedListContext.Schema,
+                    Table = LastChangedListContext.MigrationsHistoryTable
+                },
+                loggerFactory)
+        { }
+
+        protected override LastChangedListContext CreateContext(DbContextOptions<LastChangedListContext> migrationContextOptions)
         {
-            var logger = loggerFactory?.CreateLogger<MigrationsLogger>();
-
-            await Policy
-                .Handle<SqlException>()
-                .WaitAndRetryAsync(
-                    5,
-                    retryAttempt =>
-                    {
-                        var value = Math.Pow(2, retryAttempt) / 4;
-                        var randomValue = new Random().Next((int)value * 3, (int)value * 5);
-                        logger?.LogInformation("Retrying after {Seconds} seconds...", randomValue);
-                        return TimeSpan.FromSeconds(randomValue);
-                    })
-                .ExecuteAsync(async ct =>
-                    {
-                        logger?.LogInformation("Running EF Migrations.");
-                        await RunInternal(connectionString, loggerFactory, ct);
-                    },
-                    cancellationToken);
-        }
-
-        private static async Task RunInternal(string connectionString, ILoggerFactory loggerFactory, CancellationToken cancellationToken)
-        {
-            var migratorOptions = new DbContextOptionsBuilder<LastChangedListContext>()
-                .UseSqlServer(
-                    connectionString,
-                    sqlServerOptions =>
-                    {
-                        sqlServerOptions.EnableRetryOnFailure();
-                        sqlServerOptions.MigrationsHistoryTable(LastChangedListContext.MigrationsHistoryTable, LastChangedListContext.Schema);
-                    });
-
-            if (loggerFactory != null)
-                migratorOptions = migratorOptions.UseLoggerFactory(loggerFactory);
-
-            using (var migrator = new LastChangedListContext(migratorOptions.Options))
-                await migrator.Database.MigrateAsync(cancellationToken);
+            return new LastChangedListContext(migrationContextOptions);
         }
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: removed the static MigrationHelper
Use instance method RunMigrationAsync instead of the static StartAsync