### PR TITLE
fix: use a specific exception if atom handler can't be resolved

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.ProjectionHandling.Syndication/AtomResolveHandlerException.cs
+++ b/src/Be.Vlaanderen.Basisregisters.ProjectionHandling.Syndication/AtomResolveHandlerException.cs
@@ -1,0 +1,16 @@
+namespace Be.Vlaanderen.Basisregisters.ProjectionHandling.Syndication
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    public class AtomResolveHandlerException : Exception
+    {
+        public AtomResolveHandlerException() { }
+
+        protected AtomResolveHandlerException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+
+        public AtomResolveHandlerException(string? message) : base(message) { }
+
+        public AtomResolveHandlerException(string? message, Exception? innerException) : base(message, innerException) { }
+    }
+}

--- a/src/Be.Vlaanderen.Basisregisters.ProjectionHandling.Syndication/Resolve.cs
+++ b/src/Be.Vlaanderen.Basisregisters.ProjectionHandling.Syndication/Resolve.cs
@@ -22,7 +22,7 @@ namespace Be.Vlaanderen.Basisregisters.ProjectionHandling.Syndication
 
                 return Enum.TryParse<TMessage>(title, out var @event) && cache.TryGetValue(@event, out var resolvedHandlers)
                     ? resolvedHandlers
-                    : throw new InvalidOperationException($"Could not resolve a handler for {title}.");
+                    : throw new AtomResolveHandlerException($"Could not resolve a handler for {title}.");
             };
         }
     }


### PR DESCRIPTION
BREAKING CHANGE: When resolving a handler for atomprojections a AtomResolveHandlerException is now
thrown